### PR TITLE
Can't use nunjucks syntax ouside of mj-text

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -111,15 +111,17 @@ function getSubject(templatePath, values) {
 }
 
 function getHtml(templatePath, values) {
-    return nunjucks.renderString(
-        mjml2html(fs.readFileSync(
-            templatePath,
-            {
-                encoding: 'utf8'
-            }
-        )).html,
-        values
-    );
+    return mjml2html(
+        nunjucks.renderString(
+            fs.readFileSync(
+                templatePath,
+                {
+                    encoding: 'utf8'
+                }
+            ),
+            values
+        )
+    ).html;
 }
 
 function replaceAllCIDByPreviewUrl(data, ctx) {

--- a/mail-templates/confirm_email/default.mjml
+++ b/mail-templates/confirm_email/default.mjml
@@ -23,13 +23,17 @@
 
         <mj-text>
           <p>This link will expire in 48 hours.</p>
+        </mj-text>
 
 {% if is_new_user %}
+        <mj-text>
           <p>If you did not sign up, you may simply ignore this email.</p>
-{% else %}
-          <p>If you did not make this request, you may simply ignore this email.</p>
-{% endif %}
         </mj-text>
+{% else %}
+        <mj-text>
+          <p>If you did not make this request, you may simply ignore this email.</p>
+        </mj-text>
+{% endif %}
       </mj-column>
     </mj-section>
   </mj-body>


### PR DESCRIPTION
# Context

Because mjml render file before nunjucks, we can't use some nunjucks syntax